### PR TITLE
Show only price and oscillator plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # backtrader_codex
 
 Ce dépôt contient un exemple minimal d'utilisation de [Backtrader](https://www.backtrader.com/) pour analyser des données financières. La stratégie définie dans `strategy.py` affiche plusieurs indicateurs techniques pour chaque bougie d'un fichier CSV.
+Un indicateur personnalisé appelé **ConfluenceOscillator** combine RSI, CCI, MACD, ATR et les bandes de Bollinger selon des pondérations prédéfinies.
 
 ## Installation
 
@@ -31,5 +32,4 @@ Exécutez simplement :
 ```bash
 python strategy.py
 ```
-
-Le script charge le fichier de données, exécute la stratégie puis affiche un graphique.
+Le script charge le fichier de données puis affiche dans la console les valeurs des indicateurs ainsi que l'oscillateur de confluence. Un graphique est généré et enregistré sous le nom `plot.png` avec uniquement le prix et le **ConfluenceOscillator**.

--- a/indicators.py
+++ b/indicators.py
@@ -1,0 +1,61 @@
+import backtrader as bt
+
+class ConfluenceOscillator(bt.Indicator):
+    lines = ('osc',)
+    params = dict(
+        rsi_period=14,
+        cci_period=14,
+        atr_period=14,
+        bb_period=20,
+        bb_devfactor=2,
+        macd_me1=12,
+        macd_me2=26,
+        macd_signal=9,
+        w_rsi=0.25,
+        w_cci=0.25,
+        w_macd=0.25,
+        w_bb=0.15,
+        w_atr=0.10,
+    )
+
+    def __init__(self):
+        self.rsi = bt.indicators.RSI(self.data.close, period=self.p.rsi_period)
+        self.cci = bt.indicators.CCI(self.data, period=self.p.cci_period)
+        self.atr = bt.indicators.ATR(self.data, period=self.p.atr_period)
+        self.macd = bt.indicators.MACD(
+            self.data.close,
+            period_me1=self.p.macd_me1,
+            period_me2=self.p.macd_me2,
+            period_signal=self.p.macd_signal,
+        )
+        self.boll = bt.indicators.BollingerBands(
+            self.data.close,
+            period=self.p.bb_period,
+            devfactor=self.p.bb_devfactor,
+        )
+        self.atr_ema = bt.indicators.EMA(self.atr, period=self.p.atr_period)
+
+    def next(self):
+        rsi_norm = max(-1.0, min(1.0, (self.rsi[0] - 50.0) / 50.0))
+        cci_norm = max(-1.0, min(1.0, self.cci[0] / 100.0))
+        macd_norm = 0.0
+        if self.macd.signal[0] != 0:
+            macd_val = self.macd.macd[0] - self.macd.signal[0]
+            macd_norm = max(-1.0, min(1.0, macd_val / abs(self.macd.signal[0])))
+        bb_range = self.boll.top[0] - self.boll.mid[0]
+        bb_norm = (self.data.close[0] - self.boll.mid[0]) / bb_range if bb_range != 0 else 0.0
+        bb_norm = max(-1.0, min(1.0, bb_norm))
+        atr_norm = 0.0
+        if self.atr_ema[0] != 0:
+            atr_norm = (self.atr[0] - self.atr_ema[0]) / self.atr_ema[0]
+        atr_norm = max(-1.0, min(1.0, atr_norm))
+
+        total_weight = self.p.w_rsi + self.p.w_cci + self.p.w_macd + self.p.w_bb + self.p.w_atr
+        osc = (
+            self.p.w_rsi * rsi_norm
+            + self.p.w_cci * cci_norm
+            + self.p.w_macd * macd_norm
+            + self.p.w_bb * bb_norm
+            + self.p.w_atr * atr_norm
+        ) / total_weight
+        self.lines.osc[0] = osc

--- a/strategy.py
+++ b/strategy.py
@@ -2,17 +2,26 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import datetime
+import matplotlib
+matplotlib.use("Agg")
 import backtrader as bt
+
+from indicators import ConfluenceOscillator
 
 
 class TestStrategy(bt.Strategy):
     def __init__(self):
-        self.rsi = bt.indicators.RSI(self.data.close, period=14)
-        self.cci = bt.indicators.CCI(self.data, period=14)
-        self.atr = bt.indicators.ATR(self.data, period=14)
-        self.macd = bt.indicators.MACD(self.data.close)
-        self.bollinger = bt.indicators.BollingerBands(self.data.close, period=20,
-                                                      devfactor=2)
+        self.rsi = bt.indicators.RSI(self.data.close, period=14, plot=False)
+        self.cci = bt.indicators.CCI(self.data, period=14, plot=False)
+        self.atr = bt.indicators.ATR(self.data, period=14, plot=False)
+        self.macd = bt.indicators.MACD(self.data.close, plot=False)
+        self.bollinger = bt.indicators.BollingerBands(
+            self.data.close, period=20, devfactor=2, plot=False
+        )
+        self.confluence = ConfluenceOscillator(self.data)
+        self.times = []
+        self.prices = []
+        self.osc_values = []
 
     def log(self, txt, dt=None):
         """Fonction d'enregistrement pour la stratégie"""
@@ -28,8 +37,12 @@ class TestStrategy(bt.Strategy):
             f"MACD: {self.macd.macd[0]:.5f}, "
             f"BB_Mid: {self.bollinger.mid[0]:.5f}, "
             f"BB_Top: {self.bollinger.top[0]:.5f}, "
-            f"BB_Bot: {self.bollinger.bot[0]:.5f}"
+            f"BB_Bot: {self.bollinger.bot[0]:.5f}, "
+            f"Confluence: {self.confluence.osc[0]:.4f}"
         )
+        self.times.append(self.data.datetime.datetime(0))
+        self.prices.append(self.data.close[0])
+        self.osc_values.append(self.confluence.osc[0])
 
 
 if __name__ == "__main__":
@@ -55,5 +68,20 @@ if __name__ == "__main__":
 
     cerebro.adddata(data)
     cerebro.broker.setcash(10000.0)
-    cerebro.run()
-    cerebro.plot()
+    strategies = cerebro.run()
+
+    strat = strategies[0]
+    import matplotlib.pyplot as plt
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True, figsize=(10, 6))
+    ax1.plot(strat.times, strat.prices, label="Close")
+    ax1.set_title("Prix")
+    ax1.legend()
+
+    ax2.plot(strat.times, strat.osc_values, label="ConfluenceOscillator")
+    ax2.set_title("ConfluenceOscillator")
+    ax2.legend()
+
+    fig.autofmt_xdate()
+    fig.tight_layout()
+    fig.savefig("plot.png")


### PR DESCRIPTION
## Summary
- hide other indicator plots in `TestStrategy`
- generate custom matplotlib plot of price and ConfluenceOscillator
- document saved plot in README

## Testing
- `pip install -r requirements.txt`
- `python strategy.py`

------
https://chatgpt.com/codex/tasks/task_e_68407d7d8e64832ba82595096f05e4a7